### PR TITLE
Allow to customize app host/port

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,9 +74,9 @@ If you choose to use MySQL instead of PostgreSQL, you should set a different dat
 Don't forget to replace all entries (beginning by `MM_` and `DB_`) in `MM_SQLSETTINGS_DATASOURCE` with the real variables values.
 
 ### Web server container
-This image is optional, you should not use it you have your own reverse-proxy. It is a simple front Web server for the Mattermost app container.
-* `MATTERMOST_ENABLE_SSL`: whether to enable SSL
-* `PLATFORM_PORT_80_TCP_PORT`: port that Mattermost image is listening on
+This image is optional, you should **not** use it you have your own reverse-proxy. It is a simple front Web server for the Mattermost app container. If you use the provided `docker-compose.yml` file, you don't have to configure anything. But if your application container is reachable on custom host and/or port (eg. if you use a container provider), you should add those two environment variables :
+* `APP_HOST`: application host address
+* `APP_PORT_NUMBER`: application HTTP port
 
 #### Install with SSL certificate
 Put your SSL certificate as `./volumes/web/cert/cert.pem` and the private key that has

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,11 +47,8 @@ services:
       - "443:443"
     restart: unless-stopped
     volumes:
-      # This directory must have cert files
+      # This directory must have cert files if you want to enable SSL
       - ./volumes/web/cert:/cert:ro
       - /etc/localtime:/etc/localtime:ro
-    # Uncomment for SSL
-    # environment:
-    #  - MATTERMOST_ENABLE_SSL=true
     links:
       - app:app

--- a/web/entrypoint.sh
+++ b/web/entrypoint.sh
@@ -1,9 +1,22 @@
 #!/bin/bash
+
+# Define default value for app container hostname and port
+APP_HOST=${APP_HOST:-app}
+APP_PORT_NUMBER=${APP_PORT_NUMBER:-80}
+
+# Check if SSL should be enabled (if certificates exists)
 if [ -f "/cert/cert.pem" -a -f "/cert/key-no-password.pem" ]; then
   echo "found certificate and key, linking ssl config"
   ssl="-ssl"
 else
   echo "linking plain config"
 fi
+# Linking Nginx configuration file
 ln -s /etc/nginx/sites-available/mattermost$ssl /etc/nginx/conf.d/mattermost.conf
+
+# Setup app host and port on configuration file
+sed -i "s/{%APP_HOST%}/${APP_HOST}/g" /etc/nginx/conf.d/mattermost.conf
+sed -i "s/{%APP_PORT%}/${APP_PORT_NUMBER}/g" /etc/nginx/conf.d/mattermost.conf
+
+# Run Nginx
 nginx -g 'daemon off;'

--- a/web/mattermost
+++ b/web/mattermost
@@ -18,7 +18,7 @@ server {
         proxy_buffers 256 16k;
         proxy_buffer_size 16k;
         proxy_read_timeout 600s;
-        proxy_pass http://app:80;
+        proxy_pass http://{%APP_HOST%}:{%APP_PORT%};
     }
 
     location / {
@@ -34,6 +34,6 @@ server {
         proxy_buffers 256 16k;
         proxy_buffer_size 16k;
         proxy_read_timeout 600s;
-        proxy_pass http://app:80;
+        proxy_pass http://{%APP_HOST%}:{%APP_PORT%};
     }
 }

--- a/web/mattermost-ssl
+++ b/web/mattermost-ssl
@@ -34,7 +34,7 @@ server {
         proxy_buffers 256 16k;
         proxy_buffer_size 16k;
         proxy_read_timeout 600s;
-        proxy_pass http://app:80;
+	proxy_pass http://{%APP_HOST%}:{%APP_PORT%};
     }
 
     location / {
@@ -51,7 +51,7 @@ server {
         proxy_buffers 256 16k;
         proxy_buffer_size 16k;
         proxy_read_timeout 600s;
-        proxy_pass http://app:80;
+	proxy_pass http://{%APP_HOST%}:{%APP_PORT%};
     }
 }
 


### PR DESCRIPTION
Allow to use custom hostname and/or port value for app container from the Web
container. Usefull for some people using containers provider (eg. #142)